### PR TITLE
feat: add support for TaxGroupVatReturn XBRL

### DIFF
--- a/src/ApiConnectors/DeclarationsApiConnector.php
+++ b/src/ApiConnectors/DeclarationsApiConnector.php
@@ -37,6 +37,13 @@ class DeclarationsApiConnector extends BaseApiConnector
         return $response->vatReturn->any ?? null;
     }
 
+    public function taxGroupReturnXBrl($documentId): string|null
+    {
+        $response = $this->getDeclarationService()->taxGroupVatReturnXbrl($documentId);
+
+        return $response->vatReturn->any ?? null;
+    }
+
     public function summaries($officeCode, $declarationYear = null): array
     {
         // this seems redundant, but it is necessary to set the office code

--- a/src/ApiConnectors/DeclarationsApiConnector.php
+++ b/src/ApiConnectors/DeclarationsApiConnector.php
@@ -45,8 +45,9 @@ class DeclarationsApiConnector extends BaseApiConnector
     public function taxGroupReturnXBrl($documentId): string|null
     {
         $response = $this->getDeclarationService()->taxGroupVatReturnXbrl($documentId);
+        $vatReturn = $this->getVatReturnResponse($response);
 
-        return $response->vatReturn->any ?? null;
+        return $vatReturn?->any ?? null;
     }
 
     public function summaries($officeCode, $declarationYear = null): array

--- a/src/Services/DeclarationService.php
+++ b/src/Services/DeclarationService.php
@@ -111,6 +111,16 @@ class DeclarationService extends BaseService
         ]);
     }
 
+    public function taxGroupVatReturnXbrl($documentId)
+    {
+        // note $this->{function_name} is the SOAP function that should exist in the WSDL
+
+        return $this->GetTaxGroupVatReturnAsXbrl([
+            'documentId' => $documentId,
+            'isMessageIdRequired' => true // If set to True the MessageReferenceSupplierVAT element will be filled in. Which is required for sending the item to logius
+        ]);
+    }
+
     public function setApproved($documentId)
     {
         // note $this->{function_name} is the SOAP function that should exist in the WSDL


### PR DESCRIPTION
Added support for TaxGroupVatReturnXBRL. These are the tax returns for fiscal units.


https://developers.twinfield.com/documentation/api/miscellaneous/declarations/#gettaxgroupvatreturnasxbrl

*The capitalization in the twinfield docs is not correct, will test the response on implementing. 